### PR TITLE
Add requirements for FAISS helper use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # cnu_crawler
+
+FAISS 기반 검색을 위한 인덱스 갱신과 질의 함수가 포함된 크롤러입니다.
+다른 프로젝트에서 다음과 같이 사용할 수 있습니다.
+
+```python
+from src import update_index, search_links
+update_index()
+print(search_links("컴퓨터"))
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ requests>=2.31
 pandas>=2.2
 tqdm>=4.66
 sentence-transformers>=2.4
-faiss-cpu>=1.7.4
-python-dateutil>=2.9
 faiss-cpu==1.8.0
+python-dateutil>=2.9
+numpy<2

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,6 @@
-"""
-CNU Notice Crawler package
-"""
+"""CNU Notice Crawler package"""
+
+from .search.index_links import update_index
+from .search.query_links import search_links
+
+__all__ = ["update_index", "search_links"]

--- a/src/search/index_links.py
+++ b/src/search/index_links.py
@@ -32,8 +32,10 @@ def load_links() -> List[Dict]:
             rows.append({"college": college, "dept": dept, "url": url.strip()})
     return rows
 
-# ── 메인 ───────────────────────────────────────────────────────
-def main():
+
+# ── 메인 로직 ─────────────────────────────────────────────────
+def update_index() -> str:
+    """links.txt를 임베딩하여 FAISS 인덱스를 갱신하고 상태 메시지를 반환."""
     links = load_links()
     model = SentenceTransformer(MODEL_NAME)
 
@@ -48,7 +50,12 @@ def main():
     META_FILE.write_bytes(pickle.dumps(pd.DataFrame(links)))
     INFO_FILE.write_text(json.dumps({"model": MODEL_NAME, "dim": int(emb.shape[1])}))
 
-    print(f"[+] indexed {len(links)} links ({emb.shape[1]}-d) → {INDEX_FILE.name}")
+    return f"[+] indexed {len(links)} links ({emb.shape[1]}-d) → {INDEX_FILE.name}"
+
+
+def main():
+    msg = update_index()
+    print(msg)
 
 if __name__ == "__main__":
     main()

--- a/src/search/query_links.py
+++ b/src/search/query_links.py
@@ -77,7 +77,8 @@ def guess_list_url(url: str) -> str:
     return url + ("&" if "?" in url else "?") + "mode=list"
 
 # ── 메인 로직 ──────────────────────────────────────────────────
-def main(query: str):
+def search_links(query: str, show_rows: int = SHOW_ROWS) -> str:
+    """주어진 검색어로 공지 목록을 조회한 뒤 문자열로 반환."""
     index, meta = load_index()
     model = SentenceTransformer(MODEL_NAME)
 
@@ -88,11 +89,17 @@ def main(query: str):
     best = re_rank(candidates, query)
 
     list_url = guess_list_url(best.url)
-    print(f"[MATCH] {best.college}/{best.dept}  →  {list_url}")
 
     scraper = GenericScraper(best.college, best.dept, list_url)
-    df = scraper.scrape().head(SHOW_ROWS)[["title", "posted_at", "url"]]
-    print(df.to_string(index=False))
+    df = scraper.scrape().head(show_rows)[["title", "posted_at", "url"]]
+
+    header = f"[MATCH] {best.college}/{best.dept}  →  {list_url}"
+    return header + "\n" + df.to_string(index=False)
+
+
+def main(query: str):
+    msg = search_links(query)
+    print(msg)
 
 # ── CLI ───────────────────────────────────────────────────────
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clean up requirements with FAISS 1.8.0 and numpy<2
- refresh README with usage example

## Testing
- `pip install --quiet faiss-cpu==1.8.0 sentence-transformers==2.4.0 numpy==1.26.4 pandas tqdm requests beautifulsoup4 python-dateutil`
- `python - <<'PY'
from src import update_index, search_links
print('index message:', update_index()[:60])
print('search message:', search_links('컴퓨터', show_rows=2).split('\n')[0])
PY`

------
https://chatgpt.com/codex/tasks/task_e_683fc48b35b4832e9a93336f18f846a2